### PR TITLE
Removing Amazon ownership statements

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,0 @@
-## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ information to effectively respond to your bug report or contribution.
 
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
+If you discover a potential security issue in this project please notify me via email (see https://github.com/KOSASIH ).
+
+Please do not create a public GitHub issue.
 
 
 ## Reporting Bugs/Feature Requests
@@ -46,12 +48,6 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
-
-
-## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
 ## Licensing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security
-via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com.
+If you discover a potential security issue in this project please notify me via email (see https://github.com/KOSASIH ).
+
 Please do **not** create a public GitHub issue.


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/KOSASIH/pi-nexus-autonomous-banking-network/issues/1834

*Description of changes:*

I've cleaned this up so that your users are not being told that this is an Amazon owned/run project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
